### PR TITLE
Install automake

### DIFF
--- a/lib/itamae/plugin/recipe/tig/default.rb
+++ b/lib/itamae/plugin/recipe/tig/default.rb
@@ -8,6 +8,7 @@ node.reverse_merge!(
 
 package "git"
 package "gcc"
+package "automake"
 
 case node[:platform]
 when "debian", "ubuntu"


### PR DESCRIPTION
```
 INFO :     execute[make configure] executed will change from 'false' to 'true'
ERROR :       stdout | ./autogen.sh
ERROR :       stdout | ./autogen.sh: running: aclocal -I tools
ERROR :       stdout | ./autogen.sh: line 17: aclocal: command not found
ERROR :       stdout | make: *** [configure] Error 127
ERROR :       Command `cd /usr/local/src/tig && make configure` failed. (exit status: 2)
ERROR :     execute[make configure] Failed.
```
