### PR TITLE
Install make

### DIFF
--- a/lib/itamae/plugin/recipe/tig/default.rb
+++ b/lib/itamae/plugin/recipe/tig/default.rb
@@ -8,7 +8,7 @@ node.reverse_merge!(
 
 package "git"
 package "gcc"
-package "automake"
+package "make"
 
 case node[:platform]
 when "debian", "ubuntu"


### PR DESCRIPTION
```
+ bundle exec rake itamae:debian8
bundle exec itamae ssh --host=debian8 --vagrant --node-yaml=recipes/node.yml recipes/install.rb
 INFO : Starting Itamae...
 INFO : Loading node data from /pipeline/build/recipes/node.yml...
 INFO : Recipe: /pipeline/build/recipes/install.rb
 INFO :   Recipe: /pipeline/build/lib/itamae/plugin/recipe/tig/default.rb
 INFO :     package[git] installed will change from 'false' to 'true'
 INFO :     package[gcc] installed will change from 'false' to 'true'
 INFO :     package[automake] installed will change from 'false' to 'true'
 INFO :     package[libncursesw5-dev] installed will change from 'false' to 'true'
 INFO :     git[/usr/local/src/tig] exist will change from 'false' to 'true'
 INFO :     execute[make configure] executed will change from 'false' to 'true'
ERROR :       stdout | /bin/sh: 1: make: not found
ERROR :       Command `cd /usr/local/src/tig && make configure` failed. (exit status: 127)
ERROR :     execute[make configure] Failed.
```
