### PR TITLE
Resolved: failure make configure on debian8

### DIFF
--- a/lib/itamae/plugin/recipe/tig/default.rb
+++ b/lib/itamae/plugin/recipe/tig/default.rb
@@ -14,6 +14,7 @@ package "make"
 case node[:platform]
 when "debian", "ubuntu"
   package "libncursesw5-dev"
+  package "pkg-config"
 when 'redhat'
   package "ncurses-devel"
 end


### PR DESCRIPTION
```
 INFO :     execute[make configure] executed will change from 'false' to 'true'
ERROR :       stdout |        GEN  configure
ERROR :       stdout | configure.ac:25: error: macro PKG_CHECK_EXISTS is not defined; is a m4 file missing?
ERROR :       stdout | tools/ax_require_defined.m4:35: AX_REQUIRE_DEFINED is expanded from...
ERROR :       stdout | tools/ax_with_curses.m4:197: _FIND_CURSES_FLAGS is expanded from...
ERROR :       stdout | ../../lib/m4sugar/m4sh.m4:639: AS_IF is expanded from...
ERROR :       stdout | tools/ax_with_curses.m4:250: AX_WITH_CURSES is expanded from...
ERROR :       stdout | configure.ac:25: the top level
ERROR :       stdout | autom4te: /usr/bin/m4 failed with exit status: 1
ERROR :       stdout | aclocal: error: echo failed with exit status: 1
ERROR :       stdout | Makefile:239: recipe for target 'configure' failed
ERROR :       stdout | make: *** [configure] Error 1
ERROR :       Command `cd /usr/local/src/tig && make configure` failed. (exit status: 2)
ERROR :     execute[make configure] Failed.
rake aborted!
```