### PR TITLE
Update CI image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   config.vm.define :centos70 do |c|
     c.vm.box = "centos/7"
     c.vm.provider :digital_ocean do |provider, override|
-      provider.image = "centos-7-0-x64"
+      provider.image = "centos-7-x64"
     end
     c.vm.hostname  = 'itamae-tig-centos70'
     c.vm.hostname  += "-#{ENV['WERCKER_BUILD_ID']}" if ENV['WERCKER_BUILD_ID']


### PR DESCRIPTION
https://app.wercker.com/sue445/itamae-plugin-recipe-tig/runs/build-centos70/59d3b488c07035000162ce3e?step=59d3b491a155ed0001059e91

```
+ vagrant up centos70 --provider=digital_ocean
Bringing machine 'centos70' up with 'digital_ocean' provider...
==> centos70: Using existing SSH key: wercker-itamae-plugin-recipe-tig
There was an issue with the request made to the DigitalOcean
API at:

Path: /v2/droplets
URI Params: {:size=>"512MB", :region=>"nyc3", :image=>"centos-7-0-x64", :name=>"itamae-tig-centos70", :ssh_keys=>[1733451], :private_networking=>false, :ipv6=>false}

The response status from the API was:

Status: 422
Response: {"id"=>"unprocessable_entity", "message"=>"You specified an invalid image for Droplet creation."}
```