### PR TITLE
Fixed. can not install tig on AmazonLinux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 env:
 - IMAGE=centos:7
 - IMAGE=debian:jessie
+- IMAGE=amazonlinux:2
 bundler_args: "--jobs=4"
 cache: bundler
 before_install:

--- a/lib/itamae/plugin/recipe/tig/default.rb
+++ b/lib/itamae/plugin/recipe/tig/default.rb
@@ -15,7 +15,7 @@ case node[:platform]
 when "debian", "ubuntu"
   package "libncursesw5-dev"
   package "pkg-config"
-when 'redhat'
+when 'redhat', "amazon"
   package "ncurses-devel"
   package "which"
 end


### PR DESCRIPTION
```
 INFO :       package[git] installed will change from 'false' to 'true'
 INFO :       package[gcc] installed will change from 'false' to 'true'
 INFO :       package[automake] installed will change from 'false' to 'true'
 INFO :       git[/usr/local/src/tig] exist will change from 'false' to 'true'
 INFO :       execute[make configure] executed will change from 'false' to 'true'
 INFO :       execute[./configure] executed will change from 'false' to 'true'
ERROR :         stdout | checking for gcc... gcc
ERROR :         stdout | checking whether the C compiler works... yes
ERROR :         stdout | checking for C compiler default output file name... a.out
ERROR :         stdout | checking for suffix of executables...
ERROR :         stdout | checking whether we are cross compiling... no
ERROR :         stdout | checking for suffix of object files... o
ERROR :         stdout | checking whether we are using the GNU C compiler... yes
ERROR :         stdout | checking whether gcc accepts -g... yes
ERROR :         stdout | checking for gcc option to accept ISO C89... none needed
ERROR :         stdout | checking how to run the C preprocessor... gcc -E
ERROR :         stdout | checking for grep that handles long lines and -e... /bin/grep
ERROR :         stdout | checking for egrep... /bin/grep -E
ERROR :         stdout | checking for ANSI C header files... yes
ERROR :         stdout | checking for sys/types.h... yes
ERROR :         stdout | checking for sys/stat.h... yes
ERROR :         stdout | checking for stdlib.h... yes
ERROR :         stdout | checking for string.h... yes
ERROR :         stdout | checking for memory.h... yes
ERROR :         stdout | checking for strings.h... yes
ERROR :         stdout | checking for inttypes.h... yes
ERROR :         stdout | checking for stdint.h... yes
ERROR :         stdout | checking for unistd.h... yes
ERROR :         stdout | checking execinfo.h usability... yes
ERROR :         stdout | checking execinfo.h presence... yes
ERROR :         stdout | checking for execinfo.h... yes
ERROR :         stdout | checking paths.h usability... yes
ERROR :         stdout | checking paths.h presence... yes
ERROR :         stdout | checking for paths.h... yes
ERROR :         stdout | checking for stdint.h... (cached) yes
ERROR :         stdout | checking for stdlib.h... (cached) yes
ERROR :         stdout | checking for string.h... (cached) yes
ERROR :         stdout | checking sys/time.h usability... yes
ERROR :         stdout | checking sys/time.h presence... yes
ERROR :         stdout | checking for sys/time.h... yes
ERROR :         stdout | checking for unistd.h... (cached) yes
ERROR :         stdout | checking wordexp.h usability... yes
ERROR :         stdout | checking wordexp.h presence... yes
ERROR :         stdout | checking for wordexp.h... yes
ERROR :         stdout | checking for gettimeofday... yes
ERROR :         stdout | checking whether environ is declared... no
ERROR :         stdout | checking whether errno is declared... yes
ERROR :         stdout | checking for mkstemps... yes
ERROR :         stdout | checking for setenv... yes
ERROR :         stdout | checking for strndup... yes
ERROR :         stdout | checking for wordexp... yes
ERROR :         stdout | checking for pkg-config... /bin/pkg-config
ERROR :         stdout | checking pkg-config is at least version 0.9.0... yes
ERROR :         stdout | checking for ncursesw via pkg-config... no
ERROR :         stdout | checking for ncursesw via fallback...
ERROR :         stdout | checking for initscr() with -lncursesw... no
ERROR :         stdout | checking for ncurses via pkg-config... no
ERROR :         stdout | checking for ncurses via fallback...
ERROR :         stdout | checking for initscr() with -lncurses... no
ERROR :         stdout | checking for Curses library... no
ERROR :         stdout | configure: error: ncurses not found
ERROR :         Command `cd /usr/local/src/tig && ./configure` failed. (exit status: 1)
ERROR :       execute[./configure] Failed.
```