### PR TITLE
Change default schema to https

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
           - 2.3
         image:
           - centos:7
-          - centos:8
           - debian:jessie
           - debian:stretch
           - debian:buster

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ tig:
   # source dir (default: /usr/local/src)
   src: /usr/local/src
   
-  # specify scheme to use in git clone (default: git)
-  scheme: git
+  # specify scheme to use in git clone (default: https)
+  scheme: https
 
   # install version (default: HEAD)
   version: 2.1.1

--- a/lib/itamae/plugin/recipe/tig/default.rb
+++ b/lib/itamae/plugin/recipe/tig/default.rb
@@ -2,7 +2,7 @@ node.reverse_merge!(
   tig: {
     prefix:  "/usr/local",
     src:     "/usr/local/src",
-    scheme:  "git",
+    scheme:  "https",
   },
 )
 


### PR DESCRIPTION
https://github.com/sue445/itamae-plugin-recipe-tig/runs/5690117449?check_suite_focus=true

```
 INFO :     git[/usr/local/src/tig] exist will change from 'false' to 'true'
ERROR :       stderr | Cloning into '/usr/local/src/tig'...
ERROR :       stderr | fatal: remote error:
ERROR :       stderr |   The unauthenticated git protocol on port 9418 is no longer supported.
ERROR :       stderr | Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
ERROR :       Command `git clone git://github.com/jonas/tig.git /usr/local/src/tig` failed. (exit status: 128)
ERROR :     git[/usr/local/src/tig] Failed.
```