### PR TITLE
Drop support jessie

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
           - "2.3"
         image:
           - centos:7
-          - debian:jessie
           - debian:stretch
           - debian:buster
           - amazonlinux:2


### PR DESCRIPTION
Jessie is already EOL
https://wiki.debian.org/LTS

Close #34